### PR TITLE
feat(CI): allows to tests support on laravel LTS 5.5.x and 6.0.x

### DIFF
--- a/.idea/laravel-settings.iml
+++ b/.idea/laravel-settings.iml
@@ -49,6 +49,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-ctype" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-mbstring" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/translation" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/translation-contracts" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
     </content>

--- a/.idea/laravel-settings.iml
+++ b/.idea/laravel-settings.iml
@@ -43,6 +43,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/object-reflector" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/recursion-context" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/resource-operations" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/type" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/squizlabs/php_codesniffer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/contracts" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -13,8 +13,6 @@
   <component name="PhpIncludePathManager">
     <include_path>
       <path value="$PROJECT_DIR$/vendor/doctrine/instantiator" />
-      <path value="$PROJECT_DIR$/vendor/doctrine/cache" />
-      <path value="$PROJECT_DIR$/vendor/doctrine/event-manager" />
       <path value="$PROJECT_DIR$/vendor/doctrine/dbal" />
       <path value="$PROJECT_DIR$/vendor/sebastian/global-state" />
       <path value="$PROJECT_DIR$/vendor/doctrine/inflector" />
@@ -27,7 +25,6 @@
       <path value="$PROJECT_DIR$/vendor/sebastian/object-enumerator" />
       <path value="$PROJECT_DIR$/vendor/sebastian/diff" />
       <path value="$PROJECT_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
-      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
       <path value="$PROJECT_DIR$/vendor/sebastian/version" />
       <path value="$PROJECT_DIR$/vendor/illuminate/database" />
       <path value="$PROJECT_DIR$/vendor/illuminate/container" />
@@ -35,8 +32,6 @@
       <path value="$PROJECT_DIR$/vendor/illuminate/contracts" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-docblock" />
       <path value="$PROJECT_DIR$/vendor/illuminate/events" />
-      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
-      <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
       <path value="$PROJECT_DIR$/vendor/psr/container" />
       <path value="$PROJECT_DIR$/vendor/nesbot/carbon" />
       <path value="$PROJECT_DIR$/vendor/psr/simple-cache" />
@@ -47,9 +42,7 @@
       <path value="$PROJECT_DIR$/vendor/phpunit/php-token-stream" />
       <path value="$PROJECT_DIR$/vendor/phpunit/php-text-template" />
       <path value="$PROJECT_DIR$/vendor/phpunit/php-code-coverage" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
       <path value="$PROJECT_DIR$/vendor/phpunit/phpunit" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-mbstring" />
       <path value="$PROJECT_DIR$/vendor/symfony/translation" />
       <path value="$PROJECT_DIR$/vendor/theseer/tokenizer" />
       <path value="$PROJECT_DIR$/vendor/symfony/contracts" />
@@ -59,9 +52,17 @@
       <path value="$PROJECT_DIR$/vendor/squizlabs/php_codesniffer" />
       <path value="$PROJECT_DIR$/vendor/mockery/mockery" />
       <path value="$PROJECT_DIR$/vendor/hamcrest/hamcrest-php" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-mbstring" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
+      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
+      <path value="$PROJECT_DIR$/vendor/symfony/translation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
+      <path value="$PROJECT_DIR$/vendor/doctrine/cache" />
+      <path value="$PROJECT_DIR$/vendor/doctrine/event-manager" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.3" />
   <component name="PhpUnit">
     <phpunit_settings>
       <PhpUnitSettings load_method="CUSTOM_LOADER" configuration_file_path="$PROJECT_DIR$/phpunit.xml" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" use_configuration_file="true" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -52,14 +52,15 @@
       <path value="$PROJECT_DIR$/vendor/squizlabs/php_codesniffer" />
       <path value="$PROJECT_DIR$/vendor/mockery/mockery" />
       <path value="$PROJECT_DIR$/vendor/hamcrest/hamcrest-php" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-mbstring" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
+      <path value="$PROJECT_DIR$/vendor/doctrine/cache" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
-      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
+      <path value="$PROJECT_DIR$/vendor/doctrine/event-manager" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-mbstring" />
       <path value="$PROJECT_DIR$/vendor/symfony/translation-contracts" />
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
-      <path value="$PROJECT_DIR$/vendor/doctrine/cache" />
-      <path value="$PROJECT_DIR$/vendor/doctrine/event-manager" />
+      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/type" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.3" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,31 @@ matrix:
   include:
     - php: 7.3
       env:
+        - CODECLIMATE=off
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: 7.3
+      env:
         - CODECLIMATE=on
+        - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
     - php: 7.4
       env:
         - CODECLIMATE=off
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: 7.4
+      env:
+        - CODECLIMATE=off
+        - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
     - php: nightly
       env:
         - CODECLIMATE=off
+        - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - php: nightly
+      env:
+        - CODECLIMATE=off
+        - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
   allow_failures:
     - php: 7.4
     - php: nightly
-
-env:
-  matrix:
-    - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
-    - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
     - php: 7.4
     - php: nightly
 
+env:
+  matrix:
+    - COMPOSER_FLAGS="--prefer-lowest" # Cover laravel 5.5.x (LTS) vendors
+    - COMPOSER_FLAGS="" # Cover laravel 6.0.x (LTS) vendors
+
 before_install:
   - |
     if [[ "$CODECLIMATE" = "on" ]]; then
@@ -40,6 +45,8 @@ before_install:
 
 install:
   - travis_retry composer install -o --no-interaction --prefer-dist --no-suggest
+  - travis_retry composer update --prefer-source $COMPOSER_FLAGS
+  - composer info illuminate/support | grep "versions"
 
 before_script:
   - |

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
-        "illuminate/support": "5.*",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "doctrine/dbal": "2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "7.*",
-        "illuminate/database": "5.*",
-        "illuminate/events": "5.*",
+        "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/events": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "squizlabs/php_codesniffer": "^3.4",
         "mockery/mockery": "^1.0"
     },


### PR DESCRIPTION
| Q | A |
| :--- | :---: |
| Issue ? | No |
| Depends on pull requests ? | No |
| Embeds pull requests ? | No  |
| Is it automatically tested ? | Yes |
| Contains unit tests ? | No |

## How to test it manually

### travis-ci
Check travis's pipeline and see correcte matrix execution; one with illuminate dependencies as 5.5.x and one other to 6.0.x

### local

- Test with illuminate 6.0.x
```
composer install
composer info illuminate/support | grep "versions" // should output `versions : * v6.0.4`
phpunit
```

- Test with illuminate 5.5.x
```
composer install
composer update --prefer-lowest
composer info illuminate/support | grep "versions" // should output `versions : * v5.5.0`
phpunit
```
